### PR TITLE
Early printk support based on kirkwood and some other arch

### DIFF
--- a/arch/arm/mach-sun4i/Kconfig
+++ b/arch/arm/mach-sun4i/Kconfig
@@ -13,6 +13,14 @@ config SW_SYSMEM_RESERVED_SIZE
 	---help---
 	  In KB size
 
+config SW_DEBUG_UART
+	int "UART to use for low-level debug"
+	depends on DEBUG_LL
+	default 0
+	help
+	  Choose the UART on which kernel low-level debug messages should be
+	  output.
+
 #config SW_PIN_TEST
 #	tristate "Test code for PIN module"
 #	default n

--- a/arch/arm/mach-sun4i/include/mach/debug-macro.S
+++ b/arch/arm/mach-sun4i/include/mach/debug-macro.S
@@ -1,46 +1,22 @@
-/* arch/arm/mach-sun4i/include/mach/debug-macro.S
- *
- * Debugging macro include header
- *
- *  Copyright (C) 1994-1999 Russell King
- *  Copyright (C) 2005 Simtec Electronics
- *
- *  Moved from linux/arch/arm/kernel/debug.S by Ben Dooks
+/*
+ * arch/arm/mach-sun4i/include/mach/debug-macro.S
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 as
  * published by the Free Software Foundation.
 */
 
-/*
-0ea1293009826da45e1019f45dfde1e557bb30df arm: return both physical and virtual addresses from addruart
-6451d7783ba5ff24eb1a544eaa6665b890f30466 arm: remove machine_desc.io_pg_offst and .phys_io
+#include <mach/hardware.h>
+#include <mach/uart_regs.h>
 
-machine_desc.phys_io        = 0x01c00000,
-machine_desc.io_pg_offst    = ((0xf1c00000) >> 18) & 0xfffc,
-*/
-
-/* Todo: implement the following function to the actual sun4i uart*/
-
-	.macro	addruart, rd, rx
-		tst	\rd,	#0
-		tst	\rx,	#0
+	.macro	addruart, rp, rv
+	ldr	\rp, =PA_UARTS_BASE
+	ldr	\rv, =PV_UARTS_BASE
+#if CONFIG_SW_DEBUG_UART != 0
+	add	\rp, \rp, #(0x400 * CONFIG_SW_DEBUG_UART)
+	add	\rv, \rv, #(0x400 * CONFIG_SW_DEBUG_UART)
+#endif
 	.endm
 
-	.macro	senduart, rd, rx
-		tst	\rd,	#0
-		tst	\rx,	#0
-		nop
-	.endm
-
-	.macro	busyuart, rd, rx
-		tst	\rd,	#0
-		tst	\rx,	#0
-		nop
-	.endm
-
-	.macro	waituart, rd, rx
-		tst	\rd,	#0
-		tst	\rx,	#0
-		nop
-	.endm
+#define UART_SHIFT	2
+#include <asm/hardware/debug-8250.S>


### PR DESCRIPTION
I thinik this may work. Also added a config parameter on which UART to use for debugging
