### PR TITLE
Reserve memory only when needed (mark 2)

### DIFF
--- a/arch/arm/mach-sun4i/core.c
+++ b/arch/arm/mach-sun4i/core.c
@@ -57,6 +57,30 @@
 #include <mach/timex.h>
 #include <mach/sys_config.h>
 
+/* Enable or disable various subsystems according to what drivers we're
+ * building with.
+ */
+
+#if defined CONFIG_FB || defined CONFIG_FB_MODULE
+	#define USE_FB
+#endif
+
+#if defined CONFIG_SUN4I_G2D || defined CONFIG_SUN4I_G2D_MODULE
+	#define USE_G2D
+#endif
+
+#if defined CONFIG_VIDEO_DECODER_SUN4I || defined CONFIG_VIDEO_DECODER_SUN4I_MODULE
+	/* The VE block is used by:
+	 *
+	 * - the Cedar video engine, drivers/media/video/sun4i
+	 *
+	 * ve_start, ve_size are also used by the contiguous-DMA module in
+	 * drivers/media/video/videobuf-dma-contig.c, but that's SH-specific
+	 * so we don't have to worry about it here.
+	 */
+	#define USE_VE
+#endif
+
 /**
  * Machine Implementations
  *
@@ -129,54 +153,78 @@ static void __init sw_core_fixup(struct machine_desc *desc,
 	pr_info("Total Detected Memory: %uMB with %d banks\n", size, mi->nr_banks);
 }
 
+#if defined USE_FB
 unsigned long fb_start = (PLAT_PHYS_OFFSET + SZ_512M - SZ_64M - SZ_32M);
 unsigned long fb_size = SZ_32M;
 EXPORT_SYMBOL(fb_start);
 EXPORT_SYMBOL(fb_size);
+#endif
 
+#if defined USE_G2D
 unsigned long g2d_start = (PLAT_PHYS_OFFSET + SZ_512M - SZ_128M);
 unsigned long g2d_size = SZ_1M * 16;
 EXPORT_SYMBOL(g2d_start);
 EXPORT_SYMBOL(g2d_size);
+#endif
 
+#if defined USE_VE
 unsigned long ve_start = (PLAT_PHYS_OFFSET + SZ_64M);
 unsigned long ve_size = (SZ_64M + SZ_16M);
 EXPORT_SYMBOL(ve_start);
 EXPORT_SYMBOL(ve_size);
+#endif
 
 static void __init sw_core_reserve(void)
 {
+    char *script_base = (char *)(PAGE_OFFSET + 0x3000000);
+
 	memblock_reserve(SYS_CONFIG_MEMBASE, SYS_CONFIG_MEMSIZE);
-	memblock_reserve(fb_start, fb_size);
+
+#if defined USE_FB
+	if (sw_cfg_get_int(script_base, "disp_init", "disp_init_enable"))
+		memblock_reserve(fb_start, fb_size);
+	else
+		fb_start = fb_size = 0xdeadbaad;
+#endif
+
+#if defined USE_G2D
+    if (sw_cfg_get_int(script_base, "g2d_para", "g2d_used"))
+    {
+		g2d_size = sw_cfg_get_int(script_base, "g2d_para", "g2d_size");
+		if ((g2d_size < 0) || (g2d_size > SW_G2D_MEM_MAX))
+			g2d_size = SW_G2D_MEM_MAX;
+
+		g2d_start = SW_G2D_MEM_BASE;
+		g2d_size = g2d_size;
+		memblock_reserve(g2d_start, g2d_size);
+    }
+    else
+    	g2d_start = g2d_size = 0xdeadbaad;
+#endif
+
+#if defined USE_VE
+    /* The users of the VE block aren't enable via script flags, so if their
+     * driver gets compiled in we have to unconditionally reserve memory for
+     * them.
+     */
 	memblock_reserve(ve_start, SZ_64M);
 	memblock_reserve(ve_start + SZ_64M, SZ_16M);
-
-#if 0
-        int g2d_used = 0;
-        char *script_base = (char *)(PAGE_OFFSET + 0x3000000);
-
-        g2d_used = sw_cfg_get_int(script_base, "g2d_para", "g2d_used");
-
-	memblock_reserve(fb_start, fb_size);
-	memblock_reserve(SYS_CONFIG_MEMBASE, SYS_CONFIG_MEMSIZE);
-	memblock_reserve(ve_start, ve_start);
-
-        if (g2d_used) {
-                g2d_size = sw_cfg_get_int(script_base, "g2d_para", "g2d_size");
-                if (g2d_size < 0 || g2d_size > SW_G2D_MEM_MAX) {
-                        g2d_size = SW_G2D_MEM_MAX;
-                }
-                g2d_start = SW_G2D_MEM_BASE;
-                g2d_size = g2d_size;
-                memblock_reserve(g2d_start, g2d_size);
-        }
-
 #endif
+
 	pr_info("Memory Reserved(in bytes):\n");
-	pr_info("\tLCD: 0x%08x, 0x%08x\n", (unsigned int)fb_start, (unsigned int)fb_size);
+#if defined USE_FB
+	if (fb_start)
+		pr_info("\tLCD: 0x%08x, 0x%08x\n", (unsigned int)fb_start, (unsigned int)fb_size);
+#endif
 	pr_info("\tSYS: 0x%08x, 0x%08x\n", (unsigned int)SYS_CONFIG_MEMBASE, (unsigned int)SYS_CONFIG_MEMSIZE);
-	pr_info("\tG2D: 0x%08x, 0x%08x\n", (unsigned int)g2d_start, (unsigned int)g2d_size);
-	pr_info("\tVE : 0x%08x, 0x%08x\n", (unsigned int)ve_start, (unsigned int)ve_size);
+#if defined USE_G2D
+	if (g2d_start)
+		pr_info("\tG2D: 0x%08x, 0x%08x\n", (unsigned int)g2d_start, (unsigned int)g2d_size);
+#endif
+#if defined USE_VE
+	if (ve_start)
+		pr_info("\tVE : 0x%08x, 0x%08x\n", (unsigned int)ve_start, (unsigned int)ve_size);
+#endif
 }
 
 void sw_irq_ack(struct irq_data *irqd)

--- a/arch/arm/mach-sun4i/core.c
+++ b/arch/arm/mach-sun4i/core.c
@@ -57,47 +57,6 @@
 #include <mach/timex.h>
 #include <mach/sys_config.h>
 
-/* Enable or disable various subsystems according to what drivers we're
- * building with.
- */
-
-#if defined CONFIG_FB || defined CONFIG_FB_MODULE
-	/* The FB block is used by:
-	 *
-	 * - the sun4i framebuffer driver, drivers/video/sun4i/disp.
-	 *
-	 * fb_start, fb_size are used in a vast number of other places but for
-	 * for platform-specific drivers, so we don't have to worry about them.
-	 *
-	 * The block will only be allocated if the disp_init/disp_init_enabled
-	 * script key is set.
-	 */
-	#define USE_FB
-#endif
-
-#if defined CONFIG_SUN4I_G2D || defined CONFIG_SUN4I_G2D_MODULE
-	/* The G2D block is used by:
-	 *
-	 * - the G2D engine, drivers/char/sun4i_g2d
-	 *
-	 * The block will only be allocated if the g2d_para/g2d_used
-	 * script key is set.
-	 */
-	#define USE_G2D
-#endif
-
-#if defined CONFIG_VIDEO_DECODER_SUN4I || defined CONFIG_VIDEO_DECODER_SUN4I_MODULE
-	/* The VE block is used by:
-	 *
-	 * - the Cedar video engine, drivers/media/video/sun4i
-	 *
-	 * ve_start, ve_size are also used by the contiguous-DMA module in
-	 * drivers/media/video/videobuf-dma-contig.c, but that's SH-specific
-	 * so we don't have to worry about it here.
-	 */
-	#define USE_VE
-#endif
-
 /**
  * Machine Implementations
  *
@@ -170,43 +129,62 @@ static void __init sw_core_fixup(struct machine_desc *desc,
 	pr_info("Total Detected Memory: %uMB with %d banks\n", size, mi->nr_banks);
 }
 
-#if defined USE_FB
+/* Only reserve certain important memory blocks if there are actually
+ * drivers which use them.
+ */
+
+#if defined CONFIG_FB || defined CONFIG_FB_MODULE
+/* The FB block is used by:
+ *
+ * - the sun4i framebuffer driver, drivers/video/sun4i/disp.
+ *
+ * fb_start, fb_size are used in a vast number of other places but for
+ * for platform-specific drivers, so we don't have to worry about them.
+ *
+ * The block will only be allocated if the disp_init/disp_init_enabled
+ * script key is set.
+ */
+
 unsigned long fb_start = (PLAT_PHYS_OFFSET + SZ_512M - SZ_64M - SZ_32M);
 unsigned long fb_size = SZ_32M;
 EXPORT_SYMBOL(fb_start);
 EXPORT_SYMBOL(fb_size);
+
+static void __init reserve_fb(void)
+{
+    char *script_base = (char *)(PAGE_OFFSET + 0x3000000);
+
+    if (sw_cfg_get_int(script_base, "disp_init", "disp_init_enable"))
+    {
+		memblock_reserve(fb_start, fb_size);
+		pr_info("\tLCD: 0x%08x, 0x%08x\n", (unsigned int)fb_start, (unsigned int)fb_size);
+    }
+	else
+		fb_start = fb_size = 0;
+}
+
+#else
+static void __init reserve_fb(void) {}
 #endif
 
-#if defined USE_G2D
+#if defined CONFIG_SUN4I_G2D || defined CONFIG_SUN4I_G2D_MODULE
+/* The G2D block is used by:
+ *
+ * - the G2D engine, drivers/char/sun4i_g2d
+ *
+ * The block will only be allocated if the g2d_para/g2d_used
+ * script key is set.
+ */
+
 unsigned long g2d_start = (PLAT_PHYS_OFFSET + SZ_512M - SZ_128M);
 unsigned long g2d_size = SZ_1M * 16;
 EXPORT_SYMBOL(g2d_start);
 EXPORT_SYMBOL(g2d_size);
-#endif
 
-#if defined USE_VE
-unsigned long ve_start = (PLAT_PHYS_OFFSET + SZ_64M);
-unsigned long ve_size = (SZ_64M + SZ_16M);
-EXPORT_SYMBOL(ve_start);
-EXPORT_SYMBOL(ve_size);
-#endif
-
-static void __init sw_core_reserve(void)
+static void __init reserve_g2d(void)
 {
-#if (defined USE_FB) || (defined USE_G2D) || (defined USE_VE)
     char *script_base = (char *)(PAGE_OFFSET + 0x3000000);
-#endif
 
-	memblock_reserve(SYS_CONFIG_MEMBASE, SYS_CONFIG_MEMSIZE);
-
-#if defined USE_FB
-	if (sw_cfg_get_int(script_base, "disp_init", "disp_init_enable"))
-		memblock_reserve(fb_start, fb_size);
-	else
-		fb_start = fb_size = 0;
-#endif
-
-#if defined USE_G2D
     if (sw_cfg_get_int(script_base, "g2d_para", "g2d_used"))
     {
 		g2d_size = sw_cfg_get_int(script_base, "g2d_para", "g2d_size");
@@ -216,34 +194,63 @@ static void __init sw_core_reserve(void)
 		g2d_start = SW_G2D_MEM_BASE;
 		g2d_size = g2d_size;
 		memblock_reserve(g2d_start, g2d_size);
+
+		pr_info("\tG2D: 0x%08x, 0x%08x\n", (unsigned int)g2d_start, (unsigned int)g2d_size);
     }
     else
     	g2d_start = g2d_size = 0;
+}
+
+#else
+static void __init reserve_g2d(void) {}
 #endif
 
-#if defined USE_VE
+#if defined CONFIG_VIDEO_DECODER_SUN4I || defined CONFIG_VIDEO_DECODER_SUN4I_MODULE
+/* The VE block is used by:
+ *
+ * - the Cedar video engine, drivers/media/video/sun4i
+ *
+ * ve_start, ve_size are also used by the contiguous-DMA module in
+ * drivers/media/video/videobuf-dma-contig.c, but that's SH-specific
+ * so we don't have to worry about it here.
+ */
+
+unsigned long ve_start = (PLAT_PHYS_OFFSET + SZ_64M);
+unsigned long ve_size = (SZ_64M + SZ_16M);
+EXPORT_SYMBOL(ve_start);
+EXPORT_SYMBOL(ve_size);
+
+static void __init reserve_ve(void)
+{
     /* The users of the VE block aren't enabled via script flags, so if their
      * driver gets compiled in we have to unconditionally reserve memory for
      * them.
      */
 	memblock_reserve(ve_start, SZ_64M);
 	memblock_reserve(ve_start + SZ_64M, SZ_16M);
+
+	pr_info("\tVE : 0x%08x, 0x%08x\n", (unsigned int)ve_start, (unsigned int)ve_size);
+}
+
+#else
+static void __init reserve_ve(void) {}
 #endif
 
+static void reserve_sys(void)
+{
+	memblock_reserve(SYS_CONFIG_MEMBASE, SYS_CONFIG_MEMSIZE);
+	pr_info("\tSYS: 0x%08x, 0x%08x\n",
+			(unsigned int)SYS_CONFIG_MEMBASE,
+			(unsigned int)SYS_CONFIG_MEMSIZE);
+}
+
+static void __init sw_core_reserve(void)
+{
 	pr_info("Memory Reserved(in bytes):\n");
-#if defined USE_FB
-	if (fb_start)
-		pr_info("\tLCD: 0x%08x, 0x%08x\n", (unsigned int)fb_start, (unsigned int)fb_size);
-#endif
-	pr_info("\tSYS: 0x%08x, 0x%08x\n", (unsigned int)SYS_CONFIG_MEMBASE, (unsigned int)SYS_CONFIG_MEMSIZE);
-#if defined USE_G2D
-	if (g2d_start)
-		pr_info("\tG2D: 0x%08x, 0x%08x\n", (unsigned int)g2d_start, (unsigned int)g2d_size);
-#endif
-#if defined USE_VE
-	if (ve_start)
-		pr_info("\tVE : 0x%08x, 0x%08x\n", (unsigned int)ve_start, (unsigned int)ve_size);
-#endif
+	reserve_sys();
+	reserve_fb();
+	reserve_g2d();
+	reserve_ve();
 }
 
 void sw_irq_ack(struct irq_data *irqd)


### PR DESCRIPTION
See: https://github.com/amery/linux-allwinner/issues/18

This is quite a lot cleaner; using #if...#endif is unavoidable, I'm afraid, but now there's only one block per case and it's much better laid out.

Because I think the pull request is going to show the various commits that make it up separately, which makes it a bit hard to follow, the overall diff against upstream is here: 

https://github.com/davidgiven/linux-allwinner/compare/amery:allwinner-v3.0-android-v2...davidgiven:dg-memory
