### PR TITLE
Attempting minor performance enhancement of the A10 wemac NIC driver

### DIFF
--- a/drivers/net/sun4i/sun4i_wemac.c
+++ b/drivers/net/sun4i/sun4i_wemac.c
@@ -295,7 +295,7 @@ __s32 emacrx_WaitDmaFinish(void)
 			local_irq_restore(flags);
 			break;
 		}
-		for(i=0;i<1000;i++);
+		//for(i=0;i<1000;i++);
 		local_irq_restore(flags);
 	}
 
@@ -1268,7 +1268,7 @@ wemac_rx(struct net_device *dev)
 		//add by penggang 20110621
 		if(!Rxcount)
 		{
-			udelay(100);
+			udelay(150); // 100
 			Rxcount = readl(db->emac_vbase + EMAC_RX_FBC_REG);
 		}
 
@@ -1567,7 +1567,7 @@ static int wemac_phy_read(struct net_device *dev, int phyaddr_unused, int reg)
 	spin_unlock_irqrestore(&db->lock,flags);
 
 	//    wemac_msleep(db, 1);		/* Wait read complete */
-	udelay(100);
+	udelay(150); //100
 
 	/* push down the phy io line and read data */
 	spin_lock_irqsave(&db->lock,flags);
@@ -1601,7 +1601,7 @@ static void wemac_phy_write(struct net_device *dev,
 	spin_unlock_irqrestore(&db->lock, flags);
 
 	//wemac_msleep(db, 1);		/* Wait write complete */
-	udelay(100);
+	udelay(150); //100
 
 	spin_lock_irqsave(&db->lock,flags);
 	/* push down the phy io line */

--- a/drivers/net/sun4i/sun4i_wemac.h
+++ b/drivers/net/sun4i/sun4i_wemac.h
@@ -1,4 +1,26 @@
 /*
+ * drivers/net/sun4i/sun4i_wemac.h
+ *
+ * (C) Copyright 2007-2012
+ * Allwinner Technology Co., Ltd. <www.allwinnertech.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+ * MA 02111-1307 USA
+ */
+
+/*
  * wemac Ethernet
  */
 

--- a/drivers/net/sun4i/sun4i_wemac.h
+++ b/drivers/net/sun4i/sun4i_wemac.h
@@ -1,31 +1,71 @@
 /*
- * drivers/net/sun4i/sun4i_wemac.h
- *
- * (C) Copyright 2007-2012
- * Allwinner Technology Co., Ltd. <www.allwinnertech.com>
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License as
- * published by the Free Software Foundation; either version 2 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston,
- * MA 02111-1307 USA
- */
-
-/*
  * wemac Ethernet
  */
 
 #ifndef _WEMACX_H_
 #define _WEMACX_H_
+
+
+/* CTL_REG */
+#define EMAC_NCR             0x00
+#define EMAC_NSR             0x01
+#define EMAC_TCR             0x02
+#define EMAC_TSR1            0x03
+#define EMAC_TSR2            0x04
+#define EMAC_RCR             0x05
+#define EMAC_RSR             0x06
+#define EMAC_ROCR            0x07
+#define EMAC_BPTR            0x08
+#define EMAC_FCTR            0x09
+#define EMAC_FCR             0x0A
+#define EMAC_EPCR            0x0B
+#define EMAC_EPAR            0x0C
+#define EMAC_EPDRL           0x0D
+#define EMAC_EPDRH           0x0E
+#define EMAC_WCR             0x0F
+
+#define EMAC_PAR             0x10
+#define EMAC_MAR             0x16
+
+#define EMAC_GPCR            0x1e
+#define EMAC_GPR             0x1f
+#define EMAC_TRPAL           0x22
+#define EMAC_TRPAH           0x23
+#define EMAC_RWPAL           0x24
+#define EMAC_RWPAH           0x25
+
+#define EMAC_VIDL            0x28
+#define EMAC_VIDH            0x29
+#define EMAC_PIDL            0x2A
+#define EMAC_PIDH            0x2B
+#define EMAC_CHIPR           0x2C
+#define EMAC_SMCR            0x2F
+#define EMAC_ETXCSR          0x30
+#define EMAC_TCCR            0x31
+#define EMAC_RCSR            0x32
+
+/* Status bits */
+
+#define NCR_EXT_PHY         (1<<7)
+#define NCR_WAKEEN          (1<<6)
+#define NCR_FCOL            (1<<4)
+#define NCR_FDX             (1<<3)
+#define NCR_LBK             (3<<1)
+#define NCR_RST             (1<<0)
+
+#define EPCR_REEP           (1<<5)
+#define EPCR_WEP            (1<<4)
+#define EPCR_EPOS           (1<<3)
+#define EPCR_ERPRR          (1<<2)
+#define EPCR_ERPRW          (1<<1)
+#define EPCR_ERRE           (1<<0)
+
+#define WCR_LINKEN          (1<<5)
+#define WCR_SAMPLEEN        (1<<4)
+#define WCR_MAGICEN         (1<<3)
+#define WCR_LINKST          (1<<2)
+#define WCR_SAMPLEST        (1<<1)
+#define WCR_MAGICST         (1<<0)
 
 /*   registers define  */
 /*  EMAC register  */
@@ -75,7 +115,7 @@
 #define EMAC_SAFX_L_REG0         (0xA4)
 #define EMAC_SAFX_H_REG0         (0xA8)
 #define EMAC_SAFX_L_REG1         (0xAC)
-#define EMAC_SAFX_H_REG1         (0xB0)       
+#define EMAC_SAFX_H_REG1         (0xB0)
 #define EMAC_SAFX_L_REG2         (0xB4)
 #define EMAC_SAFX_H_REG2         (0xB8)
 #define EMAC_SAFX_L_REG3         (0xBC)
@@ -160,7 +200,7 @@
 
 
 //set up PHY
-#define PHY_AUTO_NEGOTIOATION  1  // 0: Normal     1: Auto(default) 
+#define PHY_AUTO_NEGOTIOATION  1  // 0: Normal     1: Auto(default)
 #define PHY_SPEED              1  // 0: 10M        1: 100M(default)
 #define EMAC_MAC_FULL          1  //0: Half duplex   1: Full duplex(default)
 
@@ -180,17 +220,17 @@
 #define EMAC_RX_UCAD        1  //0: Not accept             1: Accept unicast Packets(default)
 #define EMAC_RX_DAF         1  //0: Normal(default)        1: DA Filtering
 #define EMAC_RX_MCO         1  //0: Not accept             1: Accept multicast Packets(default)
-#define EMAC_RX_MHF         1  //0: Disable(default)       1: Enable Hash filter 
+#define EMAC_RX_MHF         1  //0: Disable(default)       1: Enable Hash filter
 #define EMAC_RX_BCO		    1  //0: Not accept             1: Accept Broadcast Packets(default)
 #define EMAC_RX_SAF         0  //0: Disable(default)       1: Enable SA Filtering
 #define EMAC_RX_SAIF        0  //0: Normal(default)        1: Inverse Filtering
-                                                           
-//set up MAC                                               
+
+//set up MAC
 #define EMAC_MAC_TFC        1  //0: Disable                1: Enable Transmit Flow Control(default)
 #define EMAC_MAC_RFC        1  //0: Disable                1: Enable Receive Flow Control(default)
 
 
-                                                           
+
 #define EMAC_MAC_FLC        1  //0: Disable                1: Enable MAC Frame Length Checking(default)
 #define EMAC_MAC_HF         0  //0: Disable(default)       1: Enable Huge Frame
 #define EMAC_MAC_DCRC       0  //0: Disable(default)       1: Enable MAC Delayed CRC
@@ -206,7 +246,7 @@
 
 #if EMAC_MAC_FULL
   #define EMAC_MAC_IPGT   0x15
-#else    
+#else
   #define EMAC_MAC_IPGT   0x12
 #endif
 
@@ -229,7 +269,9 @@
 #define WEMAC_PLATF_32BITONLY   (0x0004)
 #define WEMAC_PLATF_EXT_PHY     (0x0008)
 #define WEMAC_PLATF_NO_EEPROM   (0x0010)
-#define WEMAC_PLATF_SIMPLE_PHY (0x0020)  /* Use NSR to find LinkStatus */
+#define WEMAC_PLATF_SIMPLE_PHY  (0x0020)  /* Use NSR to find LinkStatus */
+
+#define EMAC_EEPROM_MAGIC		(0x444D394B)
 
 /* platfrom data for platfrom device structure's platfrom_data field */
 


### PR DESCRIPTION
I have the ICS4 20120609 image on Mele A2000 and there are some networking issues with the wired 'wemac' NIC. It can not quite stream videos that it can otherwise play perfectly from local storage.

Using the amery 3.0.31+ branch from github, and no other changes (no tweaking, or network settings)
I did a simple network test based on:

```
# time wget -O /dev/null http://192.168.30.44:8001/testfile.bin
```

(from Mac Pro running OSX 10.7.3 with llink-2.3.2). Not the best test perhaps, but gave me a good indicator.

Result from 10 such tests were:
2012-06-19 09:33:53 (3.55 MB/s) - `/dev/null' saved [114720238/114720238]
real    0m21.040s
real    0m15.308s
real    0m27.234s
real    0m15.715s
real    0m21.850s
real    0m35.226s
real    0m20.613s
real    0m42.949s
real    0m14.064s
real    0m16.241s

Pretty fluctuating. From 14s to 42s. In fact, it struggles to start, once the tcp.win size starts to increase, it generally finds its feet, and when it hits 5Mb/s to goes up to 9Mb/s without issues.

First thing I noticed in drivers/net/sun4i/sun4i_wemac.c is the CPU Busyloop. I guess some debug 'delay' hack that was left in. 

```
-               for(i=0;i<1000;i++);
+               //for(i=0;i<1000;i++);
```

and test again:

2012-06-19 09:44:48 (7.69 MB/s) - `/dev/null' saved [114720238/114720238]
real    0m14.499s
sys     0m13.950s
real    0m20.611s
real    0m18.529s  
real    0m16.415s
real    0m18.042s
real    0m23.971s
real    0m24.729s
real    0m20.156s
real    0m19.658s

Which is a little better. More stable, but still fluctuating somewhat. I noticed the RX DMA interrupt handler has some udelay(100) code, I try halving them to 50:

real    0m15.632s
real    0m18.445s
real    0m15.785s
real    0m49.516s
real    0m15.115s
real    0m13.810s
real    0m38.116s
real    0m15.428s
real    0m17.187s
real    0m22.096s

That appears to have made it worse. So finally, I change udelay(100) to udelay(150):

real    0m12.270s
real    0m12.248s
real    0m12.138s
real    0m12.155s
real    0m12.145s
real    0m12.159s
real    0m12.182s
real    0m12.122s
real    0m12.533s
real    0m12.134s

Perfect. It no longer struggles, and just starts at 5Mb/s and goes directly to 9Mb/s. This could be somewhat "tweaked" specifically for the Mele A2000 (my hardware) but it sure makes it perform better. I really want to try the ICS4 kernel with this change, but I do not know how to build/boot such a kernel.
