### PR TITLE
gpu: drm: mali_drv: fixed integration with 3.x kernels DRM

### DIFF
--- a/drivers/gpu/drm/mali/mali_drv.c
+++ b/drivers/gpu/drm/mali/mali_drv.c
@@ -12,13 +12,14 @@
  * @file mali_drv.c
  * Implementation of the Linux device driver entrypoints for Mali DRM
  */
-
 #include <linux/vermagic.h>
-#include "drmP.h"
+#include <drm/drmP.h>
 #include "mali_drv.h"
 
+static struct platform_device *dev0;
+static struct platform_device *dev1;
 
-void mali_drm_preclose(struct drm_device *dev)
+void mali_drm_preclose(struct drm_device *dev, struct drm_file *file_priv)
 {
 }
 
@@ -26,7 +27,7 @@ void mali_drm_lastclose(struct drm_device *dev)
 {
 }
 
-static int mali_drm_suspend(struct drm_device *dev)
+static int mali_drm_suspend(struct drm_device *dev, pm_message_t state)
 {
 	return 0;
 }
@@ -46,7 +47,7 @@ static int mali_drm_unload(struct drm_device *dev)
 	return 0;
 }
 
-static struct drm_driver driver = 
+static struct drm_driver driver =
 {
 	.driver_features = DRIVER_BUS_PLATFORM,
 	.load = mali_drm_load,
@@ -58,7 +59,36 @@ static struct drm_driver driver =
 	.lastclose = mali_drm_lastclose,
 	.suspend = mali_drm_suspend,
 	.resume = mali_drm_resume,
+	.ioctls = NULL,
+	.fops = {
+		 .owner = THIS_MODULE,
+		 .open = drm_open,
+		 .release = drm_release,
+		 .unlocked_ioctl = drm_ioctl,
+		 .mmap = drm_mmap,
+		 .poll = drm_poll,
+		 .fasync = drm_fasync,
+	},
+	.name = DRIVER_NAME,
+	.desc = DRIVER_DESC,
+	.date = DRIVER_DATE,
+	.major = DRIVER_MAJOR,
+	.minor = DRIVER_MINOR,
+	.patchlevel = DRIVER_PATCHLEVEL,
+};
 
+static struct drm_driver driver1 =
+{
+	.driver_features = DRIVER_BUS_PLATFORM,
+	.load = mali_drm_load,
+	.unload = mali_drm_unload,
+	.context_dtor = NULL,
+	.reclaim_buffers = NULL,
+	.reclaim_buffers_idlelocked = NULL,
+	.preclose = mali_drm_preclose,
+	.lastclose = mali_drm_lastclose,
+	.suspend = mali_drm_suspend,
+	.resume = mali_drm_resume,
 	.ioctls = NULL,
 	.fops = {
 		 .owner = THIS_MODULE,
@@ -80,15 +110,25 @@ static struct drm_driver driver =
 int mali_drm_init(struct platform_device *dev)
 {
 	printk(KERN_INFO "Mali DRM initialize, driver name: %s, version %d.%d\n", DRIVER_NAME, DRIVER_MAJOR, DRIVER_MINOR);
-	driver.num_ioctls = 0;
-
-	return drm_platform_init(&driver, dev);
+	if (dev == dev0) {
+		driver.num_ioctls = 0;
+		driver.kdriver.platform_device = dev;
+		return drm_platform_init(&driver, dev);
+	} else if (dev == dev1) {
+		driver1.num_ioctls = 0;
+		driver1.kdriver.platform_device = dev;
+		return drm_platform_init(&driver1, dev);
+	}
+	return 0;
 }
 
 void mali_drm_exit(struct platform_device *dev)
 {
-
-	return drm_platform_exit(&driver, dev);
+	if (driver.kdriver.platform_device == dev) {
+		drm_platform_exit(&driver, dev);
+	} else if (driver1.kdriver.platform_device == dev) {
+		drm_platform_exit(&driver1, dev);
+	}
 }
 
 static int __devinit mali_platform_drm_probe(struct platform_device *dev)
@@ -127,12 +167,16 @@ static struct platform_driver platform_drm_driver = {
 
 static int __init mali_platform_drm_init(void)
 {
+	dev0 = platform_device_register_simple("mali_drm", 0, NULL, 0);
+	dev1 = platform_device_register_simple("mali_drm", 1, NULL, 0);
 	return platform_driver_register( &platform_drm_driver );
 }
 
 static void __exit mali_platform_drm_exit(void)
 {
 	platform_driver_unregister( &platform_drm_driver );
+	platform_device_unregister(dev0);
+	platform_device_unregister(dev1);
 }
 
 #ifdef MODULE
@@ -145,9 +189,6 @@ module_exit(mali_platform_drm_exit);
 MODULE_DESCRIPTION(DRIVER_DESC);
 MODULE_VERSION(DRIVER_VERSION);
 MODULE_AUTHOR(DRIVER_AUTHOR);
-/* MODULE_LICENSE(DRIVER_LICENSE); */
-MODULE_LICENSE("GPL");
+MODULE_LICENSE(DRIVER_LICENSE);
 MODULE_ALIAS(DRIVER_ALIAS);
 MODULE_INFO(vermagic, VERMAGIC_STRING);
-
-

--- a/drivers/gpu/drm/mali/mali_drv.h
+++ b/drivers/gpu/drm/mali/mali_drv.h
@@ -14,7 +14,7 @@
 #define DRIVER_AUTHOR	"ARM Ltd."
 #define DRIVER_NAME		"mali_drm"
 #define DRIVER_DESC		"DRM module for Mali-200, Mali-400"
-#define DRIVER_LICENSE  "GPLv2"
+#define DRIVER_LICENSE  "GPL v2"
 #define DRIVER_ALIAS    "platform:mali_drm"
 #define DRIVER_DATE		"20101111"
 #define DRIVER_VERSION  "0.2"


### PR DESCRIPTION
mali_drv is taken from http://www.igloocommunity.org git. 
Now you can use X11 DRI2 Mali-400 drivers from ARM with default xorg.conf. 
This commit also adds support for two framebuffers for Mali DRM, they are different platform devices called mali_drm.0 and mali_drm.1 accordingly.
