### PR TITLE
sched: remove useless export

### DIFF
--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -9411,5 +9411,3 @@ struct cgroup_subsys cpuacct_subsys = {
 	.subsys_id = cpuacct_subsys_id,
 };
 #endif	/* CONFIG_CGROUP_CPUACCT */
-
-EXPORT_SYMBOL_GPL(nr_running);


### PR DESCRIPTION
This is a partial revert of commit 67aaa26dab7f7345864e774ffc3be382218f1090.
- this export is unneeded since Smartass version 2.
- it is misplaced: it shouldn't be added at the end of the file but at the end of the corresponding function (through this doesn't trigger any compilation error).
