### PR TITLE
Fix sysfs exported gpio name (example "gpio254")

### DIFF
--- a/drivers/gpio/gpio-sunxi.c
+++ b/drivers/gpio/gpio-sunxi.c
@@ -182,11 +182,9 @@ static int sunxi_gpio_request(struct gpio_chip *chip, unsigned offset)
 	if ((offset > chip->ngpio - 1) || (offset < 0))
 		return -EINVAL;
 
-	/* Set sysfs exported gpio name (example "gpio254_ph20") */
-	sprintf((char *)(chip->names[offset]), "gpio%d_p%c%d",
-		offset+chip->base,
-		'a'+sgpio->data[offset].info.port-1,
-		sgpio->data[offset].info.port_num);
+	/* Set sysfs exported gpio name (example "gpio254") */
+	sprintf((char *)(chip->names[offset]), "gpio%d",
+		offset+chip->base);
 
 	sgpio->data[offset].gpio_handler = gpio_request_ex("gpio_para",
 						sgpio->data[offset].pin_name);


### PR DESCRIPTION
Accoding to Documentation/gpio.txt GPIO signals have paths like /sys/class/gpio/gpio42/ (for GPIO #42).
Existing version break compatability with program where use this interface. For example avrdude (avr programmer, module linuxgpio) work ok with this change (tested).
