### PR TITLE
Fixed symlink to sys_config.h

### DIFF
--- a/arch/arm/mach-sun7i/include/mach/sys_config.h
+++ b/arch/arm/mach-sun7i/include/mach/sys_config.h
@@ -1,1 +1,1 @@
-../plat/sys_config.h
+../../../plat-sunxi/sys_config.h


### PR DESCRIPTION
This is a fix to a broken symlink.
