### PR TITLE
WLAN: bcmdhd compilation fix

### DIFF
--- a/drivers/net/wireless/bcmdhd/wl_iw.c
+++ b/drivers/net/wireless/bcmdhd/wl_iw.c
@@ -384,6 +384,7 @@ typedef int (*iw_handler)(struct net_device *dev, struct iw_request_info *info,
 	void *wrqu, char *extra);
 #endif /* WIRELESS_EXT < 13 */
 
+#ifdef CONFIG_WEXT_PRIV
 #if WIRELESS_EXT > 12
 static int
 wl_iw_set_leddc(
@@ -435,6 +436,7 @@ wl_iw_set_pm(
 #if WIRELESS_EXT > 17
 #endif /* WIRELESS_EXT > 17 */
 #endif /* WIRELESS_EXT > 12 */
+#endif /* CONFIG_WEXT_PRIV */
 
 int
 wl_iw_send_priv_event(
@@ -2919,6 +2921,7 @@ enum {
 	WL_IW_SET_LAST
 };
 
+#ifdef CONFIG_WEXT_PRIV
 static iw_handler wl_iw_priv_handler[] = {
 	wl_iw_set_leddc,
 	wl_iw_set_vlanmode,
@@ -2951,15 +2954,20 @@ static struct iw_priv_args wl_iw_priv_args[] = {
 #endif /* WIRELESS_EXT > 17 */
 	{ 0, 0, 0, { 0 } }
 };
+#endif /* CONFIG_WEXT_PRIV */
 
 const struct iw_handler_def wl_iw_handler_def =
 {
+#ifdef CONFIG_WEXT_PRIV
 	.num_standard = ARRAYSIZE(wl_iw_handler),
 	.num_private = ARRAY_SIZE(wl_iw_priv_handler),
 	.num_private_args = ARRAY_SIZE(wl_iw_priv_args),
+#endif /* CONFIG_WEXT_PRIV */
 	.standard = (iw_handler *) wl_iw_handler,
+#ifdef CONFIG_WEXT_PRIV
 	.private = wl_iw_priv_handler,
 	.private_args = wl_iw_priv_args,
+#endif /* CONFIG_WEXT_PRIV */
 #if WIRELESS_EXT >= 19
 	get_wireless_stats: dhd_get_wireless_stats,
 #endif /* WIRELESS_EXT >= 19 */


### PR DESCRIPTION
If bcmdhd is the only choosed wireless module (no b43, ...), compilation
fails on 'bcmdhd/wl_iw.c'.
drivers/net/wireless/bcmdhd/wl_iw.c:2958:2: error: unknown field
‘num_private’ specified in initializer
...
If we look at 'include/net/iw_handler.h' the private fields of the
struct iw_handler_def are only defined if 'CONFIG_WEXT_PRIV' is set.

I am using ARCH=arm.
