### PR TITLE
added patch to build kernel-build-helper-scripts for arm

### DIFF
--- a/scripts/Kbuild.include
+++ b/scripts/Kbuild.include
@@ -222,13 +222,17 @@ if_changed = $(if $(strip $(any-prereq) $(arg-check)),                       \
 	$(echo-cmd) $(cmd_$(1));                                             \
 	echo 'cmd_$@ := $(make-cmd)' > $(dot-target).cmd)
 
+ifeq ($(KBUILD_SCRIPTROOT),)
+KBUILD_SCRIPTROOT=.
+endif
+
 # Execute the command and also postprocess generated .d dependencies file.
 if_changed_dep = $(if $(strip $(any-prereq) $(arg-check) ),                  \
 	@set -e;                                                             \
 	$(echo-cmd) $(cmd_$(1));                                             \
-	scripts/basic/fixdep $(depfile) $@ '$(make-cmd)' > $(dot-target).tmp;\
-	rm -f $(depfile);                                                    \
-	mv -f $(dot-target).tmp $(dot-target).cmd)
+	$(KBUILD_SCRIPTROOT)/scripts/basic/fixdep $(depfile) $@ '$(make-cmd)' > $(dot-target).tmp;\
+ 	rm -f $(depfile);                                                    \
+ 	mv -f $(dot-target).tmp $(dot-target).cmd)
 
 # Usage: $(call if_changed_rule,foo)
 # Will check if $(cmd_foo) or any of the prerequisites changed,

--- a/scripts/Makefile.build
+++ b/scripts/Makefile.build
@@ -290,13 +290,17 @@ cmd_record_mcount = 						\
 	fi;
 endif
 
+ifeq ($(KBUILD_SCRIPTROOT),)
+KBUILD_SCRIPTROOT=.
+endif
+
 define rule_cc_o_c
 	$(call echo-cmd,checksrc) $(cmd_checksrc)			  \
 	$(call echo-cmd,cc_o_c) $(cmd_cc_o_c);				  \
 	$(cmd_modversions)						  \
 	$(call echo-cmd,record_mcount)					  \
 	$(cmd_record_mcount)						  \
-	scripts/basic/fixdep $(depfile) $@ '$(call make-cmd,cc_o_c)' >    \
+	$(KBUILD_SCRIPTROOT)/scripts/basic/fixdep $(depfile) $@ '$(call make-cmd,cc_o_c)' >    \
 	                                              $(dot-target).tmp;  \
 	rm -f $(depfile);						  \
 	mv -f $(dot-target).tmp $(dot-target).cmd

--- a/scripts/kconfig/Makefile
+++ b/scripts/kconfig/Makefile
@@ -11,6 +11,12 @@ else
 Kconfig := Kconfig
 endif
 
+ifdef KBUILD_SCRIPTROOT
+CONF = $(KBUILD_SCRIPTROOT)/scripts/kconfig/conf
+else
+CONF = $(obj)/conf
+endif
+
 xconfig: $(obj)/qconf
 	$< $(Kconfig)
 
@@ -20,31 +26,31 @@ gconfig: $(obj)/gconf
 menuconfig: $(obj)/mconf
 	$< $(Kconfig)
 
-config: $(obj)/conf
+config: $(CONF)
 	$< --oldaskconfig $(Kconfig)
 
 nconfig: $(obj)/nconf
 	$< $(Kconfig)
 
-oldconfig: $(obj)/conf
+oldconfig: $(CONF)
 	$< --$@ $(Kconfig)
-
-silentoldconfig: $(obj)/conf
+ 
+silentoldconfig: $(CONF)
 	$(Q)mkdir -p include/generated
 	$< --$@ $(Kconfig)
 
-localyesconfig localmodconfig: $(obj)/streamline_config.pl $(obj)/conf
+localyesconfig localmodconfig: $(obj)/streamline_config.pl $(CONF)
 	$(Q)mkdir -p include/generated
 	$(Q)perl $< --$@ $(srctree) $(Kconfig) > .tmp.config
 	$(Q)if [ -f .config ]; then 					\
 			cmp -s .tmp.config .config ||			\
 			(mv -f .config .config.old.1;			\
 			 mv -f .tmp.config .config;			\
-			 $(obj)/conf --silentoldconfig $(Kconfig);	\
+			 $(CONF) --silentoldconfig $(Kconfig);		\
 			 mv -f .config.old.1 .config.old)		\
 	else								\
 			mv -f .tmp.config .config;			\
-			$(obj)/conf --silentoldconfig $(Kconfig);	\
+			$(CONF) --silentoldconfig $(Kconfig);		\
 	fi
 	$(Q)rm -f .tmp.config
 
@@ -73,18 +79,18 @@ update-po-config: $(obj)/kxgettext $(obj)/gconf.glade.h
 
 PHONY += allnoconfig allyesconfig allmodconfig alldefconfig randconfig
 
-allnoconfig allyesconfig allmodconfig alldefconfig randconfig: $(obj)/conf
+allnoconfig allyesconfig allmodconfig alldefconfig randconfig: $(CONF)
 	$< --$@ $(Kconfig)
 
 PHONY += listnewconfig oldnoconfig savedefconfig defconfig
 
-listnewconfig oldnoconfig: $(obj)/conf
+listnewconfig oldnoconfig: $(CONF)
 	$< --$@ $(Kconfig)
 
-savedefconfig: $(obj)/conf
+savedefconfig: $(CONF)
 	$< --$@=defconfig $(Kconfig)
 
-defconfig: $(obj)/conf
+defconfig: $(CONF)
 ifeq ($(KBUILD_DEFCONFIG),)
 	$< --defconfig $(Kconfig)
 else
@@ -92,7 +98,7 @@ else
 	$(Q)$< --defconfig=arch/$(SRCARCH)/configs/$(KBUILD_DEFCONFIG) $(Kconfig)
 endif
 
-%_defconfig: $(obj)/conf
+%_defconfig: $(CONF)
 	$(Q)$< --defconfig=arch/$(SRCARCH)/configs/$@ $(Kconfig)
 
 # Help text used by make help

--- a/scripts/mod/Makefile
+++ b/scripts/mod/Makefile
@@ -1,6 +1,12 @@
 hostprogs-y	:= modpost mk_elfconfig
 always		:= $(hostprogs-y) empty.o
 
+ifdef KBUILD_SCRIPTROOT
+MKELFCONFIG = $(KBUILD_SCRIPTROOT)/scripts/mod/mk_elfconfig
+else
+MKELFCONFIG = $(obj)/mk_elfconfig
+endif
+
 modpost-objs	:= modpost.o file2alias.o sumversion.o
 
 # dependencies on generated files need to be listed explicitly
@@ -8,9 +14,9 @@ modpost-objs	:= modpost.o file2alias.o sumversion.o
 $(obj)/modpost.o $(obj)/file2alias.o $(obj)/sumversion.o: $(obj)/elfconfig.h
 
 quiet_cmd_elfconfig = MKELF   $@
-      cmd_elfconfig = $(obj)/mk_elfconfig < $< > $@
+      cmd_elfconfig = $(MKELFCONFIG) < $< > $@
 
-$(obj)/elfconfig.h: $(obj)/empty.o $(obj)/mk_elfconfig FORCE
+$(obj)/elfconfig.h: $(obj)/empty.o $(MKELFCONFIG) FORCE
 	$(call if_changed,elfconfig)
 
 targets += elfconfig.h


### PR DESCRIPTION
this patch (taken from linaro: https://lists.ubuntu.com/archives/kernel-team/2012-March/019515.html) allows to crosscompile the "scripts" located in /scripts on kernel tree

doing this allows for building single modules against a cross-compiled kernel using only a few headers and these crosscompiled scripts
