### PR TITLE
rename to sunxi_nand to avoid naming conflict

### DIFF
--- a/drivers/block/sunxi_nand/nfd/Makefile
+++ b/drivers/block/sunxi_nand/nfd/Makefile
@@ -1,10 +1,12 @@
 
-obj-$(CONFIG_SUNXI_NAND)  += nand.o
-nand-y := nand_blk.o  dma_for_nand.o int_for_nand.o \
-         ../src/format/nand_format.o \
-         ../src/logic/bad_manage.o ../src/logic/logic_ctl.o ../src/logic/mapping.o ../src/logic/mapping_base.o ../src/logic/merge.o ../src/logic/read_reclaim.o ../src/logic/wear_levelling.o ../src/logic/logic_cache.o \
-         ../src/scan/nand_scan.o ../src/scan/nand_id.o\
-         ../src/physic/nand_phy.o ../src/physic/nand_simple_r.o ../src/physic/nand_simple_w.o \
-         ../nfc/nfc_r.o ../nfc/nfc_w.o
+obj-$(CONFIG_SUNXI_NAND)  += sunxi_nand.o
+sunxi_nand-y := nand_blk.o dma_for_nand.o int_for_nand.o \
+                ../src/format/nand_format.o \
+                ../src/logic/bad_manage.o ../src/logic/logic_ctl.o ../src/logic/mapping.o \
+                ../src/logic/mapping_base.o ../src/logic/merge.o ../src/logic/read_reclaim.o \
+                ../src/logic/wear_levelling.o ../src/logic/logic_cache.o \
+                ../src/scan/nand_scan.o ../src/scan/nand_id.o \
+                ../src/physic/nand_phy.o ../src/physic/nand_simple_r.o ../src/physic/nand_simple_w.o \
+                ../nfc/nfc_r.o ../nfc/nfc_w.o
 
 


### PR DESCRIPTION
rename to sunxi_nand to avoid conflict with drivers/mtd/nand/nand.ko

discussion started here:  https://groups.google.com/d/topic/linux-sunxi/cYdLsiirve0/discussion

Essentially, with `sun7i_defconfig`, the sunxi_nand module never gets installed properly because it ends up having the same name as another kernel module.
