### PR TITLE
Minor fixes at the branch for 3.10 because kuid_t is now structure

### DIFF
--- a/fs/proc/base.c
+++ b/fs/proc/base.c
@@ -1013,7 +1013,7 @@ static int oom_adjust_permission(struct inode *inode, int mask)
 
 	p = get_proc_task(inode);
 	if(p) {
-		uid = task_uid(p);
+		uid = task_uid(p).val;
 		put_task_struct(p);
 	}
 
@@ -1021,7 +1021,7 @@ static int oom_adjust_permission(struct inode *inode, int mask)
 	 * System Server (uid == 1000) is granted access to oom_adj of all 
 	 * android applications (uid > 10000) as and services (uid >= 1000)
 	 */
-	if (p && (current_fsuid() == 1000) && (uid >= 1000)) {
+	if (p && (current_fsuid().val == 1000) && (uid >= 1000)) {
 		if (inode->i_mode >> 6 & mask) {
 			return 0;
 		}

--- a/kernel/sched/core.c
+++ b/kernel/sched/core.c
@@ -7726,7 +7726,7 @@ cpu_cgroup_allow_attach(struct cgroup *cgrp, struct cgroup_taskset *tset)
 		tcred = __task_cred(task);
 
 		if ((current != task) && !capable(CAP_SYS_NICE) &&
-		    cred->euid != tcred->uid && cred->euid != tcred->suid)
+		    cred->euid.val != tcred->uid.val && cred->euid.val != tcred->suid.val)
 			return -EACCES;
 	}
 


### PR DESCRIPTION
These minor changes allow to compile a kernel using the source from the experimental branch for 3.10. Otherwise errors occuered due to the introduction of a structure kuid_t. Now the val of this structure should be used.
