### PR TITLE
mm: fix a crash when CONFIG_DEBUG_VM is enabled

### DIFF
--- a/include/linux/mm.h
+++ b/include/linux/mm.h
@@ -789,7 +789,10 @@ static inline struct address_space *page_mapping(struct page *page)
 {
 	struct address_space *mapping = page->mapping;
 
-	VM_BUG_ON(PageSlab(page));
+	/* This happens if someone calls flush_dcache_page on slab page */
+	if (unlikely(PageSlab(page)))
+		return NULL;
+
 	if (unlikely(PageSwapCache(page)))
 		mapping = &swapper_space;
 	else if ((unsigned long)mapping & PAGE_MAPPING_ANON)


### PR DESCRIPTION
This commit fixes a crash that could happen when CONFIG_DEBUG_VM is enabled.

This commit is backported from
https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=03e5ac2fc3bf6f4140db0371e8bb4243b24e3e02
