### PR TITLE
Add otg support for bananapro

### DIFF
--- a/arch/arm/boot/dts/sun7i-a20-bananapro.dts
+++ b/arch/arm/boot/dts/sun7i-a20-bananapro.dts
@@ -180,6 +180,10 @@
 	status = "okay";
 };
 
+&otg_sram {
+	status = "okay";
+};
+
 &pio {
 	gmac_power_pin_bananapro: gmac_power_pin@0 {
 		allwinner,pins = "PH23";
@@ -202,6 +206,13 @@
 		allwinner,pull = <SUN4I_PINCTRL_PULL_UP>;
 	};
 
+	usb0_id_detect_pin_bananapro: usb0_id_detect_pin@0 {
+		allwinner,pins = "PH3";
+		allwinner,function = "gpio_in";
+		allwinner,drive = <SUN4I_PINCTRL_10_MA>;
+		allwinner,pull = <SUN4I_PINCTRL_PULL_UP>;
+	};
+	
 	usb1_vbus_pin_bananapro: usb1_vbus_pin@0 {
 		allwinner,pins = "PH0";
 		allwinner,function = "gpio_out";
@@ -222,6 +233,10 @@
 		allwinner,drive = <SUN4I_PINCTRL_10_MA>;
 		allwinner,pull = <SUN4I_PINCTRL_NO_PULL>;
 	};
+};
+
+&reg_usb0_vbus {
+	status = "okay";
 };
 
 &reg_usb1_vbus {
@@ -262,7 +277,15 @@
 	status = "okay";
 };
 
+&usb_otg {
+	dr_mode = "otg";
+	status = "okay";
+};
+
 &usbphy {
+        pinctrl-names = "default";
+	pinctrl-0 = <&usb0_id_detect_pin_bananapro>;
+	usb0_id_det-gpio = <&pio 7 3 GPIO_ACTIVE_HIGH>; /* PH3 */
 	usb1_vbus-supply = <&reg_usb1_vbus>;
 	usb2_vbus-supply = <&reg_usb2_vbus>;
 	status = "okay";


### PR DESCRIPTION
bananapro is similar to banana. It also has one OTG port. We should enable it.