### PR TITLE
Modify 'ccm_fmt.height' to reference the correct value (fmt.pix.height)

### DIFF
--- a/drivers/media/video/sun4i_csi/csi0/sun4i_drv_csi.c
+++ b/drivers/media/video/sun4i_csi/csi0/sun4i_drv_csi.c
@@ -877,7 +877,7 @@ static int vidioc_s_fmt_vid_cap(struct file *file, void *priv,
 
 	ccm_fmt.code = csi_fmt->ccm_fmt;//linux-3.0
 	ccm_fmt.width = f->fmt.pix.width;//linux-3.0
-	ccm_fmt.height = f->fmt.pix.width;//linux-3.0
+	ccm_fmt.height = f->fmt.pix.height;//linux-3.0
 
 	ret = v4l2_subdev_call(dev->sd,video,s_mbus_fmt,&ccm_fmt);//linux-3.0
 	if (ret < 0) {

--- a/drivers/media/video/sun4i_csi/csi1/sun4i_drv_csi.c
+++ b/drivers/media/video/sun4i_csi/csi1/sun4i_drv_csi.c
@@ -880,7 +880,7 @@ static int vidioc_s_fmt_vid_cap(struct file *file, void *priv,
 
 	ccm_fmt.code = csi_fmt->ccm_fmt;//linux-3.0
 	ccm_fmt.width = f->fmt.pix.width;//linux-3.0
-	ccm_fmt.height = f->fmt.pix.width;//linux-3.0
+	ccm_fmt.height = f->fmt.pix.height;//linux-3.0
 
 	ret = v4l2_subdev_call(dev->sd,video,s_mbus_fmt,&ccm_fmt);//linux-3.0
 	if (ret < 0) {


### PR DESCRIPTION
ccm_fmt.height = f->fmt.pix.width is wrong.
ccm_fmt.height = f->fmt.pix.height is correct.
